### PR TITLE
Refactor load of demo content to point at matiasvillaverde.com

### DIFF
--- a/Memory/Modules/Game/Application Logic/DataManager/Local/GameLocalDataManager.swift
+++ b/Memory/Modules/Game/Application Logic/DataManager/Local/GameLocalDataManager.swift
@@ -52,24 +52,33 @@ extension GameLocalDataManager {
         var output = [Content]()
 
         // Iterates the array
-        json.forEach { jsonPlayers in
+        json.forEach { contentJson in
 
             guard output.count < amount else { return }
 
-            guard
-
-                let image = jsonPlayers["image"] as? String,
-                let imageURL = URL(string: "http://www.matiasvillaverde.com/mobile-ios-vipergame/\(image).png"),
-                let description = jsonPlayers["description"] as? String
-                else { fatalError("Developer: Wrong format of content.") }
-
-            let player = Logo(name: image.capitalized, description: description, imageURL: imageURL)
-
-            output.append(player)
+            let content = map(json: contentJson)
+            output.append(content)
 
         }
 
         return output
+    }
+
+    func map(json: NSDictionary) -> Logo {
+
+        let keyImage = "image"
+        let keyImageURL = "http://matiasvillaverde.com/mobile-ios-vipergame/"
+        let keyImageURLExtension = ".png"
+        let keyDescription = "description"
+
+        guard
+            let image = json[keyImage] as? String,
+            let imageURL = URL(string: keyImageURL + image + keyImageURLExtension),
+            let description = json[keyDescription] as? String
+            else { fatalError("Developer: Wrong format of content.") }
+
+        return Logo(name: image.capitalized, description: description, imageURL: imageURL)
+
     }
 
 }


### PR DESCRIPTION
# Description

Fix bug of loading images from my personal server. Now the app loads demo content from a local JSON and the images from http://matiasvillaverde.com/mobile-ios-vipergame/*. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Run the app
- [x] Check that images are loading

# Checklist:

-  [x] My code follows the style guidelines of this project
-  [x] I have performed a self-review of my own code
-  [x] I have commented my code, particularly in hard-to-understand areas
-  [x] I have made corresponding changes to the documentation
-  [x] My changes generate no new warnings
-  [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
-  [x] Any dependent changes have been merged and published in downstream modules